### PR TITLE
fix: redis disconnected before HTTP server listener stopped

### DIFF
--- a/authorization-server/src/redis/redis.service.spec.ts
+++ b/authorization-server/src/redis/redis.service.spec.ts
@@ -53,7 +53,7 @@ describe('RedisService', () => {
         .spyOn(service, 'disconnect')
         .mockImplementation(async () => {});
 
-      await service.onModuleDestroy();
+      await service.onApplicationShutdown();
     });
 
     afterEach(async function () {

--- a/authorization-server/src/redis/redis.service.ts
+++ b/authorization-server/src/redis/redis.service.ts
@@ -1,7 +1,7 @@
 import {
   Injectable,
   Logger,
-  OnModuleDestroy,
+  OnApplicationShutdown,
   OnModuleInit,
 } from '@nestjs/common';
 import * as Redis from 'ioredis';
@@ -10,7 +10,7 @@ import { ConfigService } from '@nestjs/config';
 @Injectable()
 export class RedisService
   extends Redis
-  implements OnModuleInit, OnModuleDestroy
+  implements OnModuleInit, OnApplicationShutdown
 {
   private readonly logger = new Logger(RedisService.name, {
     timestamp: true,
@@ -39,7 +39,7 @@ export class RedisService
     }
   }
 
-  async onModuleDestroy() {
+  async onApplicationShutdown() {
     this.logger.debug('disconnecting');
     this.disconnect();
   }


### PR DESCRIPTION
This PR fixes incorrect hook used to close the Redis connection.