### PR TITLE
chore: added optional exceptions to bypass authentication 

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -11,6 +11,15 @@ server {
         proxy_pass http://auth-server/auth/refresh-token;
     }
 
+#     you can enable and if necessary extend this rule to include any exceptions
+#     for files fetched by a web browser without Authorization header
+#
+#     WARNIG!!!
+#     Test carefully after changing this. Any mistakes here may result in disabling authentication completely
+#     location ~* ^.*\.(css|js|html|htm)$ {
+#        proxy_pass http://backend;
+#     }
+
     location / {
         auth_request /token_introspection;
         proxy_pass http://backend;


### PR DESCRIPTION
This PR adds Nginx example rule that disables authentication for static urls like .html .css. js