### PR TITLE
chore: limited node engine versions to versions compatible

### DIFF
--- a/authorization-server/package.json
+++ b/authorization-server/package.json
@@ -5,6 +5,10 @@
   "author": "",
   "private": true,
   "license": "UNLICENSED",
+  "engineStrict": true,
+  "engines": {
+    "node": ">=14 <17"
+  },
   "scripts": {
     "clean": "rimraf dist node_modules",
     "prebuild": "rimraf dist",


### PR DESCRIPTION
This PR sets node engine versions constraints to versions compatible with the dependencies