### PR TITLE
Fixing /auth/logout not working in dev

### DIFF
--- a/nginx/nginx.dev.conf
+++ b/nginx/nginx.dev.conf
@@ -11,6 +11,10 @@ server {
         proxy_pass http://host.docker.internal:3000/auth/login;
     }
 
+    location = /auth/logout {
+        proxy_pass http://host.docker.internal:3000/auth/logout;
+    }
+
     location = /auth/refresh-token {
         proxy_pass http://host.docker.internal:3000/auth/refresh-token;
     }


### PR DESCRIPTION
This PR fixes incorrect nginx configuration for dev not including `/auth/logout` entry.