### PR TITLE
feat: allowing REDIS_PASSWORD .env variable set to an empty string

### DIFF
--- a/authorization-server/src/modules/app/env-vars-validation-schema.ts
+++ b/authorization-server/src/modules/app/env-vars-validation-schema.ts
@@ -28,7 +28,7 @@ export const envVarsValidationSchema = Joi.object({
 
   REDIS_HOST: Joi.string().hostname().default('127.0.0.1'),
   REDIS_PORT: Joi.number().port().default(6379),
-  REDIS_PASSWORD: Joi.string().optional(),
+  REDIS_PASSWORD: Joi.string().optional().allow(''),
 
   FAIL_ON_REDIS_UNAVAILABLE: Joi.bool().default(false),
 


### PR DESCRIPTION
This PR changes validation of the `REDIS_PASSWORD` env variable during app start so that it can be set to an empty string like in `.env.example` file