### PR TITLE
chore: Upgrading GH actions dependencies

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Setup app dependencies
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: '16'
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Setup app dependencies
         uses: actions/setup-node@v2

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,7 +24,7 @@ jobs:
         with:
           node-version: '16'
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
         with:
           path: |

--- a/.github/workflows/deployment-release.yaml
+++ b/.github/workflows/deployment-release.yaml
@@ -41,7 +41,7 @@ jobs:
             echo "Branch ${{ github.ref }} is not configured for deployment"
             exit 1
           fi
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Setup app dependencies
         uses: actions/setup-node@v2

--- a/.github/workflows/deployment-release.yaml
+++ b/.github/workflows/deployment-release.yaml
@@ -44,7 +44,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Setup app dependencies
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: '16'
 

--- a/.github/workflows/deployment-release.yaml
+++ b/.github/workflows/deployment-release.yaml
@@ -48,7 +48,7 @@ jobs:
         with:
           node-version: '16'
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
         with:
           path: |

--- a/.github/workflows/deployment.yaml
+++ b/.github/workflows/deployment.yaml
@@ -53,7 +53,7 @@ jobs:
         with:
           node-version: '16'
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
         with:
           path: |

--- a/.github/workflows/deployment.yaml
+++ b/.github/workflows/deployment.yaml
@@ -46,7 +46,7 @@ jobs:
             echo "Branch ${{ github.ref }} is not configured for deployment"
             exit 1
           fi
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Setup app dependencies
         uses: actions/setup-node@v2

--- a/.github/workflows/deployment.yaml
+++ b/.github/workflows/deployment.yaml
@@ -49,7 +49,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Setup app dependencies
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: '16'
 


### PR DESCRIPTION
This PR upgrades GH actions dependencies that cause the `The 'save-state' command is deprecated and will be disabled soon.` warning message.