### PR TITLE
feat: two backends

### DIFF
--- a/backend-server/index.js
+++ b/backend-server/index.js
@@ -3,6 +3,8 @@ const bodyParser = require('body-parser');
 
 const app = express();
 
+const BACKEND_INSTANCE_ID = process.env.BACKEND_INSTANCE_ID || 'backend';
+
 app.use(bodyParser.urlencoded({ extended: true }));
 app.use((req, res, next) => {
     console.log(`incoming request: ${JSON.stringify({ url: req.url, headers: req.headers, method: req.method, body: req.body })}`);
@@ -10,13 +12,13 @@ app.use((req, res, next) => {
 });
 
 app.use(((req, res) => {
-    res.send({ message: 'backend response', timestamp: new Date().toISOString() });
+    res.send({ message: `${BACKEND_INSTANCE_ID} response`, timestamp: new Date().toISOString() });
 }));
 
 const server = app.listen(80);
 
 server.on('listening', () => {
-    console.log(`backend server listening`);
+    console.log(`${BACKEND_INSTANCE_ID} server listening`);
 });
 
 // below required for docker to not wait for container stopped

--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -4,6 +4,7 @@ services:
   webserver:
     restart: unless-stopped
     image: did-auth-proxy-webserver
+    pull_policy: never
     build:
       context: nginx
     ports:
@@ -16,6 +17,7 @@ services:
   backend:
     restart: unless-stopped
     image: did-auth-proxy-backend
+    pull_policy: never
     build:
       context: backend-server
     networks:

--- a/docker-compose.two-backends.yaml
+++ b/docker-compose.two-backends.yaml
@@ -1,0 +1,90 @@
+version: "3.8"
+
+services:
+  webserver:
+    restart: unless-stopped
+    depends_on:
+      - backend-1
+      - backend-2
+      - auth-server
+    image: did-auth-proxy-webserver
+    pull_policy: never
+    build:
+      context: nginx
+    volumes:
+      - ./nginx/nginx.two-backends.conf:/opt/bitnami/nginx/conf/server_blocks/nginx.conf
+    ports:
+      - "127.0.0.1:8080:80"
+    networks:
+      backend:
+
+  backend-1:
+    restart: unless-stopped
+    image: did-auth-proxy-backend
+    pull_policy: never
+    build:
+      context: backend-server
+    environment:
+      BACKEND_INSTANCE_ID: backend-1
+    networks:
+      backend:
+
+  backend-2:
+    restart: unless-stopped
+    image: did-auth-proxy-backend
+    pull_policy: never
+    build:
+      context: backend-server
+    environment:
+      BACKEND_INSTANCE_ID: backend-2
+    networks:
+      backend:
+
+  auth-server:
+    depends_on:
+      - redis
+    restart: unless-stopped
+    image: did-auth-proxy-auth-server
+    build:
+      context: authorization-server
+    environment:
+      - LOG_LEVEL=info
+      - PORT=80
+      - RPC_URL=https://volta-rpc.energyweb.org/
+      - CACHE_SERVER_URL=https://identitycache-dev.energyweb.org/v1
+      - CACHE_SERVER_LOGIN_PRVKEY=eab5e5ccb983fad7bf7f5cb6b475a7aea95eff0c6523291b0c0ae38b5855459c
+      - DID_REGISTRY_ADDRESS=0xc15d5a57a8eb0e1dcbe5d88b8f9a82017e5cc4af
+      - ENS_REGISTRY_ADDRESS=0xd7CeF70Ba7efc2035256d828d5287e2D285CD1ac
+      - ENS_RESOLVER_ADDRESS=0xcf72f16Ab886776232bea2fcf3689761a0b74EfE
+      - IPFS_HOST=ewipfsgwtest.infura-ipfs.io
+      - IPFS_PORT=443
+      - REDIS_HOST=redis
+      - REDIS_PORT=6379
+      - REDIS_PASSWORD=redis
+      - JWT_SECRET=asecretstring
+      - ACCEPTED_ROLES=
+      - JWT_ACCESS_TTL=3600
+      - JWT_REFRESH_TTL=86400
+      - AUTH_COOKIE_NAME=Auth
+      - AUTH_COOKIE_ENABLED=false
+      - AUTH_COOKIE_SECURE=true
+    networks:
+      backend:
+
+  redis:
+    image: bitnami/redis:latest
+    restart: unless-stopped
+    ports:
+      - '127.0.0.1:6379:6379'
+    environment:
+      - REDIS_PASSWORD=redis
+    networks:
+      backend:
+    volumes:
+      - redis-data:/bitnami/redis/data
+
+volumes:
+  redis-data:
+
+networks:
+  backend:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -7,6 +7,7 @@ services:
       - backend
       - auth-server
     image: did-auth-proxy-webserver
+    pull_policy: never
     build:
       context: nginx
     ports:
@@ -17,6 +18,7 @@ services:
   backend:
     restart: unless-stopped
     image: did-auth-proxy-backend
+    pull_policy: never
     build:
       context: backend-server
     networks:

--- a/nginx/nginx.two-backends.conf
+++ b/nginx/nginx.two-backends.conf
@@ -1,0 +1,68 @@
+server {
+    listen       80;
+    listen  [::]:80;
+    server_name  _;
+}
+
+server {
+    listen       80;
+    listen  [::]:80;
+    server_name  ssi-hub.org;
+
+    location = /auth {
+        proxy_pass http://auth-server/auth;
+    }
+
+    location = /auth/login {
+        proxy_pass http://auth-server/auth/login;
+    }
+
+    location = /auth/logout {
+        proxy_pass http://auth-server/auth/logout;
+    }
+
+    location = /auth/refresh-token {
+        proxy_pass http://auth-server/auth/refresh-token;
+    }
+
+#     you can enable and if necessary extend this rule to include any exceptions
+#     for files fetched by a web browser without Authorization header
+#
+#     WARNIG!!!
+#     Test carefully after changing this. Any mistakes here may result in disabling authentication completely
+#     location ~* ^.*\.(css|js|html|htm)$ {
+#        proxy_pass http://backend;
+#     }
+
+    location / {
+        auth_request /token_introspection;
+        proxy_pass http://backend-1;
+    }
+
+    location = /token_introspection {
+        internal;
+        proxy_method      GET;
+        proxy_set_header  Authorization "$http_authorization";
+        proxy_set_header  Content-Length "";
+        proxy_pass        http://auth-server/auth/token-introspection;
+    }
+}
+
+server {
+    listen       80;
+    listen  [::]:80;
+    server_name  miner-data.org;
+
+    location / {
+        auth_request /token_introspection;
+        proxy_pass http://backend-2;
+    }
+
+    location = /token_introspection {
+        internal;
+        proxy_method      GET;
+        proxy_set_header  Authorization "$http_authorization";
+        proxy_set_header  Content-Length "";
+        proxy_pass        http://auth-server/auth/token-introspection;
+    }
+}

--- a/postman/DID Auth - two backends.postman_collection.json
+++ b/postman/DID Auth - two backends.postman_collection.json
@@ -1,0 +1,272 @@
+{
+	"info": {
+		"_postman_id": "9fe4504b-02b7-4902-a763-83291d031084",
+		"name": "DID Auth - two backends",
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+	},
+	"item": [
+		{
+			"name": "ssi-hub.org/auth/login",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"if (pm.response.code === 201) {",
+							"    var data = pm.response.json();",
+							"",
+							"    pm.environment.set('accessToken', data.access_token);",
+							"    pm.environment.set('refreshToken', data.refresh_token);",
+							"}"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"method": "POST",
+				"header": [
+					{
+						"key": "host",
+						"value": "ssi-hub.org",
+						"type": "default"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "{\n    \"identityToken\": \"{{identityToken}}\"\n}",
+					"options": {
+						"raw": {
+							"language": "json"
+						}
+					}
+				},
+				"url": {
+					"raw": "http://localhost:8080/auth/login",
+					"protocol": "http",
+					"host": [
+						"localhost"
+					],
+					"port": "8080",
+					"path": [
+						"auth",
+						"login"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "ssi-hub.org/auth/refresh-token",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"if (pm.response.code === 201) {",
+							"    var data = pm.response.json();",
+							"",
+							"    pm.environment.set('accessToken', data.access_token);",
+							"    pm.environment.set('refreshToken', data.refresh_token);",
+							"}"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"method": "POST",
+				"header": [
+					{
+						"key": "host",
+						"value": "ssi-hub.org",
+						"type": "default"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "{\n    \"refreshToken\": \"{{refreshToken}}\"\n}",
+					"options": {
+						"raw": {
+							"language": "json"
+						}
+					}
+				},
+				"url": {
+					"raw": "http://localhost:8080/auth/refresh-token",
+					"protocol": "http",
+					"host": [
+						"localhost"
+					],
+					"port": "8080",
+					"path": [
+						"auth",
+						"refresh-token"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "ssi-hub.org/any-path",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							""
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"auth": {
+					"type": "bearer",
+					"bearer": [
+						{
+							"key": "token",
+							"value": "{{accessToken}}",
+							"type": "string"
+						}
+					]
+				},
+				"method": "GET",
+				"header": [
+					{
+						"key": "host",
+						"value": "ssi-hub.org",
+						"type": "default"
+					}
+				],
+				"url": {
+					"raw": "http://localhost:8080/any-path",
+					"protocol": "http",
+					"host": [
+						"localhost"
+					],
+					"port": "8080",
+					"path": [
+						"any-path"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "miner-data.org/any-path",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							""
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"auth": {
+					"type": "bearer",
+					"bearer": [
+						{
+							"key": "token",
+							"value": "{{accessToken}}",
+							"type": "string"
+						}
+					]
+				},
+				"method": "GET",
+				"header": [
+					{
+						"key": "host",
+						"value": "miner-data.org",
+						"type": "default"
+					}
+				],
+				"url": {
+					"raw": "http://localhost:8080/any-path",
+					"protocol": "http",
+					"host": [
+						"localhost"
+					],
+					"port": "8080",
+					"path": [
+						"any-path"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "ssi-hub.org/auth/logout",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"if (pm.response.code === 201 || pm.response.code === 403) {",
+							"    pm.environment.unset('accessToken');",
+							"    pm.environment.unset('refreshToken');",
+							"}"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"method": "POST",
+				"header": [
+					{
+						"key": "host",
+						"value": "ssi-hub.org",
+						"type": "default"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "{\n    \"refreshToken\": \"{{refreshToken}}\",\n    \"allDevices\": false\n}",
+					"options": {
+						"raw": {
+							"language": "json"
+						}
+					}
+				},
+				"url": {
+					"raw": "http://localhost:8080/auth/logout",
+					"protocol": "http",
+					"host": [
+						"localhost"
+					],
+					"port": "8080",
+					"path": [
+						"auth",
+						"logout"
+					]
+				}
+			},
+			"response": []
+		}
+	],
+	"event": [
+		{
+			"listen": "prerequest",
+			"script": {
+				"type": "text/javascript",
+				"exec": [
+					""
+				]
+			}
+		},
+		{
+			"listen": "test",
+			"script": {
+				"type": "text/javascript",
+				"exec": [
+					""
+				]
+			}
+		}
+	]
+}


### PR DESCRIPTION
This PR validates and demonstrates ability of the `did-auth-proxy` to be used in front of two backends served from two different domains.