### PR TITLE
fix(CD): changing deployment workflows IPFS_HOST

### DIFF
--- a/.github/workflows/deployment-release.yaml
+++ b/.github/workflows/deployment-release.yaml
@@ -76,8 +76,10 @@ jobs:
           DID_REGISTRY_ADDRESS: '0xc15d5a57a8eb0e1dcbe5d88b8f9a82017e5cc4af'
           ENS_REGISTRY_ADDRESS: '0xd7CeF70Ba7efc2035256d828d5287e2D285CD1ac'
           ENS_RESOLVER_ADDRESS: '0xcf72f16Ab886776232bea2fcf3689761a0b74EfE'
-          IPFS_HOST: 'ewipfsgwtest.infura-ipfs.io'
-          IPFS_PORT: 443
+          IPFS_HOST: ipfs.infura.io
+          IPFS_PORT: 5001
+          IPFS_PROJECTID: ${{ secrets.IPFS_PROJECTID }}
+          IPFS_PROJECTSECRET: ${{ secrets.IPFS_PROJECTSECRET }}
           REDIS_HOST: 'localhost'
           REDIS_PORT: 61379
           JWT_SECRET: 'asecret'

--- a/.github/workflows/deployment.yaml
+++ b/.github/workflows/deployment.yaml
@@ -81,8 +81,10 @@ jobs:
           DID_REGISTRY_ADDRESS: '0xc15d5a57a8eb0e1dcbe5d88b8f9a82017e5cc4af'
           ENS_REGISTRY_ADDRESS: '0xd7CeF70Ba7efc2035256d828d5287e2D285CD1ac'
           ENS_RESOLVER_ADDRESS: '0xcf72f16Ab886776232bea2fcf3689761a0b74EfE'
-          IPFS_HOST: 'ewipfsgwtest.infura-ipfs.io'
-          IPFS_PORT: 443
+          IPFS_HOST: ipfs.infura.io
+          IPFS_PORT: 5001
+          IPFS_PROJECTID: ${{ secrets.IPFS_PROJECTID }}
+          IPFS_PROJECTSECRET: ${{ secrets.IPFS_PROJECTSECRET }}
           REDIS_HOST: 'localhost'
           REDIS_PORT: 61379
           JWT_SECRET: 'asecret'


### PR DESCRIPTION
This PR fixes deployment workflows failing after the `ewipfsgwtest.infura-ipfs.io` hostname became unavailable.