### PR TITLE
feat: adding `GET /auth/refresh_token` endpoint

### DIFF
--- a/authorization-server/src/modules/auth/auth.controller.spec.ts
+++ b/authorization-server/src/modules/auth/auth.controller.spec.ts
@@ -1141,6 +1141,7 @@ describe('AuthController', () => {
   describe('refreshWithPost()', function () {
     let spy: jest.SpyInstance;
     let refreshToken: string;
+    let mockReqest: Request;
     let mockResponse: Response;
     let result: LoginResponseDto | undefined;
     let exception: Error;
@@ -1157,13 +1158,13 @@ describe('AuthController', () => {
         expiresIn: mockConfigService.get('JWT_REFRESH_TTL'),
       });
 
+      mockReqest = createRequest({
+        user: refreshToken,
+      });
       mockResponse = createResponse();
 
       try {
-        result = await controller.refreshWithPost(
-          { refreshToken },
-          mockResponse,
-        );
+        result = await controller.refreshWithPost(mockReqest, mockResponse);
       } catch (err) {
         exception = err;
       }

--- a/authorization-server/src/modules/auth/auth.controller.spec.ts
+++ b/authorization-server/src/modules/auth/auth.controller.spec.ts
@@ -14,7 +14,11 @@ import { NonceService } from './nonce.service';
 import { SiweInitResponseDto } from './dto/siwe-init-response.dto';
 import { ParsedQs } from 'qs';
 import { SiweVerifyRequestDto } from './dto/siwe-verify-request.dto';
-import { BadRequestException, UnauthorizedException } from '@nestjs/common';
+import {
+  BadRequestException,
+  ForbiddenException,
+  UnauthorizedException,
+} from '@nestjs/common';
 
 function mockLoginRequestResponse(didAccessTokenPayload: AuthorisedUser) {
   const mockRequest = createRequest();
@@ -853,7 +857,7 @@ describe('AuthController', () => {
     });
   });
 
-  describe('refresh()', function () {
+  describe('refreshCommon()', function () {
     describe('when executed', function () {
       let response: LoginResponseDto | undefined;
       let responseCookies: Record<string, ResponseCookie>;
@@ -878,7 +882,7 @@ describe('AuthController', () => {
         }));
 
         const expResponse = createResponse();
-        response = await controller.refresh({ refreshToken }, expResponse);
+        response = await controller.refreshCommon(refreshToken, expResponse);
         responseCookies = expResponse.cookies;
       });
 
@@ -900,7 +904,7 @@ describe('AuthController', () => {
 
           const expResponse = createResponse();
 
-          response = await controller.refresh({ refreshToken }, expResponse);
+          response = await controller.refreshCommon(refreshToken, expResponse);
 
           responseCookies = expResponse.cookies;
         });
@@ -957,7 +961,7 @@ describe('AuthController', () => {
           });
 
           const expResponse = createResponse();
-          response = await controller.refresh({ refreshToken }, expResponse);
+          response = await controller.refreshCommon(refreshToken, expResponse);
           responseCookies = expResponse.cookies;
         });
 
@@ -990,7 +994,7 @@ describe('AuthController', () => {
           });
 
           const expResponse = createResponse();
-          response = await controller.refresh({ refreshToken }, expResponse);
+          response = await controller.refreshCommon(refreshToken, expResponse);
           responseCookies = expResponse.cookies;
         });
 
@@ -1035,7 +1039,7 @@ describe('AuthController', () => {
           });
 
           const expResponse = createResponse();
-          response = await controller.refresh({ refreshToken }, expResponse);
+          response = await controller.refreshCommon(refreshToken, expResponse);
           responseCookies = expResponse.cookies;
         });
 
@@ -1079,7 +1083,7 @@ describe('AuthController', () => {
           });
 
           const expResponse = createResponse();
-          response = await controller.refresh({ refreshToken }, expResponse);
+          response = await controller.refreshCommon(refreshToken, expResponse);
           responseCookies = expResponse.cookies;
         });
 
@@ -1116,7 +1120,7 @@ describe('AuthController', () => {
         const expResponse = createResponse();
 
         try {
-          await controller.refresh({ refreshToken: 'invalid' }, expResponse);
+          await controller.refreshCommon('invalid', expResponse);
         } catch (err) {
           exceptionThrown = err;
         }
@@ -1130,6 +1134,420 @@ describe('AuthController', () => {
 
       it('should not set auth cookie', async function () {
         expect(responseCookies[authCookieName]).toBeUndefined();
+      });
+    });
+  });
+
+  describe('refreshWithPost()', function () {
+    let spy: jest.SpyInstance;
+    let refreshToken: string;
+    let mockResponse: Response;
+    let result: LoginResponseDto | undefined;
+    let exception: Error;
+
+    beforeEach(async function () {
+      spy = jest.spyOn(controller, 'refreshCommon').mockResolvedValueOnce({
+        access_token: 'access_token',
+        refresh_token: 'refresh_token',
+        type: 'Bearer',
+        expires_in: 120,
+      } as LoginResponseDto);
+
+      refreshToken = sign({ random: Math.random() }, 'aSecret', {
+        expiresIn: mockConfigService.get('JWT_REFRESH_TTL'),
+      });
+
+      mockResponse = createResponse();
+
+      try {
+        result = await controller.refreshWithPost(
+          { refreshToken },
+          mockResponse,
+        );
+      } catch (err) {
+        exception = err;
+      }
+    });
+
+    it('should execute', async function () {
+      expect(exception).toBeUndefined();
+    });
+
+    it('should call refreshCommon()', async function () {
+      expect(spy).toHaveBeenCalledWith(refreshToken, mockResponse);
+    });
+
+    it('should return refreshCommon() return value', async function () {
+      expect(result).toEqual({
+        access_token: 'access_token',
+        expires_in: 120,
+        refresh_token: 'refresh_token',
+        type: 'Bearer',
+      });
+    });
+  });
+
+  describe('refreshWithGet()', function () {
+    let request: Request;
+    let response: Response;
+    let exception: Error;
+    let spyRefreshCommon: jest.SpyInstance;
+    let result: LoginResponseDto | undefined;
+
+    beforeEach(async function () {
+      request = createRequest();
+      response = createResponse();
+
+      spyRefreshCommon = jest
+        .spyOn(controller, 'refreshCommon')
+        .mockResolvedValueOnce({
+          access_token: 'access_token',
+          refresh_token: 'refresh_token',
+          type: 'Bearer',
+          expires_in: 120,
+        } as LoginResponseDto);
+    });
+
+    afterEach(async function () {
+      response = undefined;
+      exception = undefined;
+    });
+
+    describe('when token is valid', function () {
+      beforeEach(async function () {
+        mockAuthService.validateRefreshToken.mockResolvedValueOnce(true);
+      });
+
+      describe('when executed with AUTH_COOKIE_ENABLED=true', function () {
+        beforeEach(async function () {
+          mockConfigService.get.mockImplementation((key: string) => {
+            return { ...configBase, AUTH_COOKIE_ENABLED: true }[key];
+          });
+        });
+
+        describe('when query string and cookie tokens provided', function () {
+          beforeEach(async function () {
+            request = createRequest({
+              query: { refresh_token: 'query refresh token' },
+              cookies: {
+                [mockConfigService.get('AUTH_COOKIE_NAME_REFRESH_TOKEN')]:
+                  'cookies refresh token',
+              },
+            });
+
+            try {
+              result = await controller.refreshWithGet(
+                request,
+                response,
+                'query refresh token',
+              );
+            } catch (err) {
+              exception = err;
+            }
+          });
+
+          it('should execute', async function () {
+            expect(exception).toBeUndefined();
+          });
+
+          it('should call refreshCommon() with query refresh token', async function () {
+            expect(spyRefreshCommon).toHaveBeenCalledWith(
+              'query refresh token',
+              response,
+            );
+
+            expect(spyRefreshCommon).toHaveBeenCalledTimes(1);
+          });
+
+          it('should resolve to a value returned by the refreshCommon()', async function () {
+            expect(result).toEqual({
+              access_token: 'access_token',
+              refresh_token: 'refresh_token',
+              type: 'Bearer',
+              expires_in: 120,
+            });
+          });
+        });
+
+        describe('when query string token only provided', function () {
+          beforeEach(async function () {
+            request = createRequest({
+              query: { refresh_token: 'query refresh token' },
+            });
+
+            try {
+              result = await controller.refreshWithGet(
+                request,
+                response,
+                'query refresh token',
+              );
+            } catch (err) {
+              exception = err;
+            }
+          });
+
+          it('should execute', async function () {
+            expect(exception).toBeUndefined();
+          });
+
+          it('should call refreshCommon() with query refresh token', async function () {
+            expect(spyRefreshCommon).toHaveBeenCalledWith(
+              'query refresh token',
+              response,
+            );
+
+            expect(spyRefreshCommon).toHaveBeenCalledTimes(1);
+          });
+
+          it('should resolve to a value returned by the refreshCommon()', async function () {
+            expect(result).toEqual({
+              access_token: 'access_token',
+              refresh_token: 'refresh_token',
+              type: 'Bearer',
+              expires_in: 120,
+            });
+          });
+        });
+
+        describe('when cookie token only provided', function () {
+          beforeEach(async function () {
+            request = createRequest({
+              cookies: {
+                [mockConfigService.get('AUTH_COOKIE_NAME_REFRESH_TOKEN')]:
+                  'cookies refresh token',
+              },
+            });
+
+            try {
+              result = await controller.refreshWithGet(
+                request,
+                response,
+                undefined,
+              );
+            } catch (err) {
+              exception = err;
+            }
+          });
+
+          it('should execute', async function () {
+            expect(exception).toBeUndefined();
+          });
+
+          it('should call refreshCommon() with cookie refresh token', async function () {
+            expect(spyRefreshCommon).toHaveBeenCalledWith(
+              'cookies refresh token',
+              response,
+            );
+
+            expect(spyRefreshCommon).toHaveBeenCalledTimes(1);
+          });
+
+          it('should resolve to a value returned by the refreshCommon()', async function () {
+            expect(result).toEqual({
+              access_token: 'access_token',
+              refresh_token: 'refresh_token',
+              type: 'Bearer',
+              expires_in: 120,
+            });
+          });
+        });
+
+        describe('when no tokens provided', function () {
+          beforeEach(async function () {
+            request = createRequest({});
+
+            try {
+              result = await controller.refreshWithGet(
+                request,
+                response,
+                undefined,
+              );
+            } catch (err) {
+              exception = err;
+            }
+          });
+
+          it('should throw UnauthorizedException', async function () {
+            expect(exception).toBeInstanceOf(UnauthorizedException);
+          });
+
+          it('should skip calling refreshCommon()', async function () {
+            expect(spyRefreshCommon).toHaveBeenCalledTimes(0);
+          });
+        });
+      });
+
+      describe('when executed with AUTH_COOKIE_ENABLED=false', function () {
+        beforeEach(async function () {
+          mockConfigService.get.mockImplementation((key: string) => {
+            return { ...configBase, AUTH_COOKIE_ENABLED: false }[key];
+          });
+        });
+
+        describe('when query string and cookie tokens provided', function () {
+          beforeEach(async function () {
+            request = createRequest({
+              query: { refresh_token: 'query refresh token' },
+              cookies: {
+                [mockConfigService.get('AUTH_COOKIE_NAME_REFRESH_TOKEN')]:
+                  'cookies refresh token',
+              },
+            });
+
+            try {
+              result = await controller.refreshWithGet(
+                request,
+                response,
+                'query refresh token',
+              );
+            } catch (err) {
+              exception = err;
+            }
+          });
+
+          it('should execute', async function () {
+            expect(exception).toBeUndefined();
+          });
+
+          it('should call refreshCommon() with query refresh token', async function () {
+            expect(spyRefreshCommon).toHaveBeenCalledWith(
+              'query refresh token',
+              response,
+            );
+
+            expect(spyRefreshCommon).toHaveBeenCalledTimes(1);
+          });
+
+          it('should resolve to a value returned by the refreshCommon()', async function () {
+            expect(result).toEqual({
+              access_token: 'access_token',
+              refresh_token: 'refresh_token',
+              type: 'Bearer',
+              expires_in: 120,
+            });
+          });
+        });
+
+        describe('when query string token only provided', function () {
+          beforeEach(async function () {
+            request = createRequest({
+              query: { refresh_token: 'query refresh token' },
+            });
+
+            try {
+              result = await controller.refreshWithGet(
+                request,
+                response,
+                'query refresh token',
+              );
+            } catch (err) {
+              exception = err;
+            }
+          });
+
+          it('should execute', async function () {
+            expect(exception).toBeUndefined();
+          });
+
+          it('should call refreshCommon() with query refresh token', async function () {
+            expect(spyRefreshCommon).toHaveBeenCalledWith(
+              'query refresh token',
+              response,
+            );
+
+            expect(spyRefreshCommon).toHaveBeenCalledTimes(1);
+          });
+
+          it('should resolve to a value returned by the refreshCommon()', async function () {
+            expect(result).toEqual({
+              access_token: 'access_token',
+              refresh_token: 'refresh_token',
+              type: 'Bearer',
+              expires_in: 120,
+            });
+          });
+        });
+
+        describe('when cookie token only provided', function () {
+          beforeEach(async function () {
+            request = createRequest({
+              cookies: {
+                [mockConfigService.get('AUTH_COOKIE_NAME_REFRESH_TOKEN')]:
+                  'cookies refresh token',
+              },
+            });
+
+            try {
+              result = await controller.refreshWithGet(
+                request,
+                response,
+                undefined,
+              );
+            } catch (err) {
+              exception = err;
+            }
+          });
+
+          it('should throw UnauthorizedException', async function () {
+            expect(exception).toBeInstanceOf(UnauthorizedException);
+          });
+
+          it('should skip calling refreshCommon()', async function () {
+            expect(spyRefreshCommon).toHaveBeenCalledTimes(0);
+          });
+        });
+
+        describe('when no tokens provided', function () {
+          beforeEach(async function () {
+            request = createRequest({});
+
+            try {
+              result = await controller.refreshWithGet(
+                request,
+                response,
+                undefined,
+              );
+            } catch (err) {
+              exception = err;
+            }
+          });
+
+          it('should throw UnauthorizedException', async function () {
+            expect(exception).toBeInstanceOf(UnauthorizedException);
+          });
+
+          it('should skip calling refreshCommon()', async function () {
+            expect(spyRefreshCommon).toHaveBeenCalledTimes(0);
+          });
+        });
+      });
+    });
+
+    describe('when token is invalid', function () {
+      beforeEach(async function () {
+        mockAuthService.validateRefreshToken.mockResolvedValueOnce(false);
+
+        request = createRequest({
+          query: { refresh_token: 'query refresh token' },
+          cookies: {
+            [mockConfigService.get('AUTH_COOKIE_NAME_REFRESH_TOKEN')]:
+              'cookies refresh token',
+          },
+        });
+
+        try {
+          result = await controller.refreshWithGet(
+            request,
+            response,
+            'query refresh token',
+          );
+        } catch (err) {
+          exception = err;
+        }
+      });
+
+      it('should throw ForbiddenException exception', async function () {
+        expect(exception).toBeInstanceOf(ForbiddenException);
       });
     });
   });

--- a/authorization-server/src/modules/auth/auth.controller.spec.ts
+++ b/authorization-server/src/modules/auth/auth.controller.spec.ts
@@ -470,11 +470,13 @@ describe('AuthController', () => {
 
       beforeEach(async function () {
         spyOnLoginCommon = jest
-          .spyOn<AuthController, keyof AuthController>(
-            controller,
-            'loginCommon',
-          )
-          .mockReturnValueOnce(Promise.resolve('a result'));
+          .spyOn(controller, 'loginCommon')
+          .mockResolvedValueOnce({
+            access_token: 'access_token',
+            refresh_token: 'refresh_token',
+            type: 'Bearer',
+            expires_in: 120,
+          } as LoginResponseDto);
 
         ({ mockRequest, mockResponse } = mockLoginRequestResponse(
           didAccessTokenPayload,
@@ -504,7 +506,12 @@ describe('AuthController', () => {
       });
 
       it('should return results of the `loginCommon` method execution', async function () {
-        expect(result).toBe('a result');
+        expect(result).toEqual({
+          access_token: 'access_token',
+          expires_in: 120,
+          refresh_token: 'refresh_token',
+          type: 'Bearer',
+        });
       });
     });
   });
@@ -580,11 +587,13 @@ describe('AuthController', () => {
     describe('when called with valid message and signature', function () {
       beforeEach(async function () {
         spyOnLoginCommon = jest
-          .spyOn<AuthController, keyof AuthController>(
-            controller,
-            'loginCommon',
-          )
-          .mockReturnValueOnce(Promise.resolve('a result'));
+          .spyOn(controller, 'loginCommon')
+          .mockResolvedValueOnce({
+            access_token: 'access_token',
+            refresh_token: 'refresh_token',
+            type: 'Bearer',
+            expires_in: 120,
+          } as LoginResponseDto);
 
         ({ mockRequest, mockResponse } = mockLoginRequestResponse(
           didAccessTokenPayload,
@@ -616,7 +625,12 @@ describe('AuthController', () => {
       });
 
       it('should return results of the `loginCommon` method execution', async function () {
-        expect(result).toBe('a result');
+        expect(result).toEqual({
+          access_token: 'access_token',
+          expires_in: 120,
+          refresh_token: 'refresh_token',
+          type: 'Bearer',
+        });
       });
     });
 
@@ -629,7 +643,12 @@ describe('AuthController', () => {
             controller,
             'loginCommon',
           )
-          .mockReturnValueOnce(Promise.resolve('a result'));
+          .mockResolvedValueOnce({
+            access_token: 'access_token',
+            refresh_token: 'refresh_token',
+            type: 'Bearer',
+            expires_in: 120,
+          } as LoginResponseDto);
 
         ({ mockRequest, mockResponse } = mockLoginRequestResponse(
           didAccessTokenPayload,
@@ -670,7 +689,12 @@ describe('AuthController', () => {
             controller,
             'loginCommon',
           )
-          .mockReturnValueOnce(Promise.resolve('a result'));
+          .mockResolvedValueOnce({
+            access_token: 'access_token',
+            refresh_token: 'refresh_token',
+            type: 'Bearer',
+            expires_in: 120,
+          } as LoginResponseDto);
 
         ({ mockRequest, mockResponse } = mockLoginRequestResponse(
           didAccessTokenPayload,

--- a/authorization-server/src/modules/auth/auth.controller.ts
+++ b/authorization-server/src/modules/auth/auth.controller.ts
@@ -200,6 +200,7 @@ export class AuthController {
   }
 
   @Get('refresh_token')
+  @ApiOkResponse({ type: LoginResponseDto })
   //compatible with the SSI-HUB implementation
   async refreshWithGet(
     @Req() req: Request,

--- a/authorization-server/src/modules/auth/auth.controller.ts
+++ b/authorization-server/src/modules/auth/auth.controller.ts
@@ -193,10 +193,10 @@ export class AuthController {
   @ApiOkResponse({ type: LoginResponseDto })
   // backwards compatibility
   async refreshWithPost(
-    @Body() body: RefreshDto,
+    @Req() req: Request,
     @Res({ passthrough: true }) res: Response,
   ): Promise<LoginResponseDto | undefined> {
-    return this.refreshCommon(body.refreshToken, res);
+    return this.refreshCommon(req.user as string, res);
   }
 
   @Get('refresh_token')

--- a/authorization-server/src/modules/auth/auth.controller.ts
+++ b/authorization-server/src/modules/auth/auth.controller.ts
@@ -200,7 +200,7 @@ export class AuthController {
   }
 
   @Get('refresh_token')
-  //compatibile with the SSI-HUB implementation
+  //compatible with the SSI-HUB implementation
   async refreshWithGet(
     @Req() req: Request,
     @Res({ passthrough: true }) res: Response,

--- a/authorization-server/src/modules/auth/guards/valid-refresh-token.guard.spec.ts
+++ b/authorization-server/src/modules/auth/guards/valid-refresh-token.guard.spec.ts
@@ -60,493 +60,520 @@ describe('ValidRefreshTokenGuard', () => {
 
   describe('canActivate()', function () {
     let result: boolean;
+    let method: 'GET' | 'POST';
 
-    describe('when AUTH_COOKIE_ENABLED==false && AUTH_HEADER_ENABLED=false', function () {
+    describe('when method is POST', function () {
       beforeEach(async function () {
-        mockConfigService.get.mockImplementation((key: string) => {
-          return {
-            ...configBase,
-            AUTH_COOKIE_ENABLED: false,
-            AUTH_HEADER_ENABLED: false,
-          }[key];
-        });
+        method = 'POST';
       });
 
-      describe('when called with no tokens', function () {
+      describe('when AUTH_COOKIE_ENABLED==false && AUTH_HEADER_ENABLED=false', function () {
         beforeEach(async function () {
-          const mockExecutionContext = createMock<ExecutionContext>({
-            switchToHttp: jest.fn().mockReturnValue({
-              getRequest: jest.fn().mockReturnValue({}),
-            }),
+          mockConfigService.get.mockImplementation((key: string) => {
+            return {
+              ...configBase,
+              AUTH_COOKIE_ENABLED: false,
+              AUTH_HEADER_ENABLED: false,
+            }[key];
           });
-
-          result = await validRefreshTokenGuard.canActivate(
-            mockExecutionContext,
-          );
         });
 
-        it('should resolve to false', async function () {
-          expect(result).toBe(false);
-        });
-
-        it('should validate no token', async function () {
-          expect(mockAuthService.validateRefreshToken).not.toHaveBeenCalled();
-        });
-      });
-
-      describe('when called with valid token in cookie only', function () {
-        beforeEach(async function () {
-          mockAuthService.validateRefreshToken.mockImplementationOnce(
-            async () => true,
-          );
-
-          const mockExecutionContext = createMock<ExecutionContext>({
-            switchToHttp: jest.fn().mockReturnValue({
-              getRequest: jest.fn().mockReturnValue({
-                cookies: { refreshToken: 'cookie refresh token' },
+        describe('when called with no tokens', function () {
+          beforeEach(async function () {
+            const mockExecutionContext = createMock<ExecutionContext>({
+              switchToHttp: jest.fn().mockReturnValue({
+                getRequest: jest.fn().mockReturnValue({
+                  method,
+                }),
               }),
-            }),
+            });
+
+            result = await validRefreshTokenGuard.canActivate(
+              mockExecutionContext,
+            );
           });
 
-          result = await validRefreshTokenGuard.canActivate(
-            mockExecutionContext,
-          );
+          it('should resolve to false', async function () {
+            expect(result).toBe(false);
+          });
+
+          it('should validate no token', async function () {
+            expect(mockAuthService.validateRefreshToken).not.toHaveBeenCalled();
+          });
         });
 
-        it('should resolve to false', async function () {
-          expect(result).toBe(false);
-        });
+        describe('when called with valid token in cookie only', function () {
+          beforeEach(async function () {
+            mockAuthService.validateRefreshToken.mockImplementationOnce(
+              async () => true,
+            );
 
-        it('should validate no token', async function () {
-          expect(mockAuthService.validateRefreshToken).not.toHaveBeenCalled();
-        });
-      });
-
-      describe('when called with valid token in body only', function () {
-        beforeEach(async function () {
-          mockAuthService.validateRefreshToken.mockImplementationOnce(
-            async () => true,
-          );
-
-          const mockExecutionContext = createMock<ExecutionContext>({
-            switchToHttp: jest.fn().mockReturnValue({
-              getRequest: jest.fn().mockReturnValue({
-                body: { refreshToken: 'body refresh token' },
+            const mockExecutionContext = createMock<ExecutionContext>({
+              switchToHttp: jest.fn().mockReturnValue({
+                getRequest: jest.fn().mockReturnValue({
+                  method,
+                  cookies: { refreshToken: 'cookie refresh token' },
+                }),
               }),
-            }),
+            });
+
+            result = await validRefreshTokenGuard.canActivate(
+              mockExecutionContext,
+            );
           });
 
-          result = await validRefreshTokenGuard.canActivate(
-            mockExecutionContext,
-          );
+          it('should resolve to false', async function () {
+            expect(result).toBe(false);
+          });
+
+          it('should validate no token', async function () {
+            expect(mockAuthService.validateRefreshToken).not.toHaveBeenCalled();
+          });
         });
 
-        it('should resolve to false', async function () {
-          expect(result).toBe(false);
-        });
+        describe('when called with valid token in body only', function () {
+          beforeEach(async function () {
+            mockAuthService.validateRefreshToken.mockImplementationOnce(
+              async () => true,
+            );
 
-        it('should validate no token', async function () {
-          expect(mockAuthService.validateRefreshToken).not.toHaveBeenCalled();
-        });
-      });
-
-      describe('when called with valid token in body and cooki', function () {
-        beforeEach(async function () {
-          mockAuthService.validateRefreshToken.mockImplementationOnce(
-            async () => true,
-          );
-
-          const mockExecutionContext = createMock<ExecutionContext>({
-            switchToHttp: jest.fn().mockReturnValue({
-              getRequest: jest.fn().mockReturnValue({
-                cookies: { refreshToken: 'cookie refresh token' },
-                body: { refreshToken: 'body refresh token' },
+            const mockExecutionContext = createMock<ExecutionContext>({
+              switchToHttp: jest.fn().mockReturnValue({
+                getRequest: jest.fn().mockReturnValue({
+                  method,
+                  body: { refreshToken: 'body refresh token' },
+                }),
               }),
-            }),
+            });
+
+            result = await validRefreshTokenGuard.canActivate(
+              mockExecutionContext,
+            );
           });
 
-          result = await validRefreshTokenGuard.canActivate(
-            mockExecutionContext,
-          );
-        });
-
-        it('should resolve to false', async function () {
-          expect(result).toBe(false);
-        });
-
-        it('should validate no token', async function () {
-          expect(mockAuthService.validateRefreshToken).not.toHaveBeenCalled();
-        });
-      });
-    });
-
-    describe('when AUTH_COOKIE_ENABLED==true && AUTH_HEADER_ENABLED=false', function () {
-      beforeEach(async function () {
-        mockConfigService.get.mockImplementation((key: string) => {
-          return {
-            ...configBase,
-            AUTH_COOKIE_ENABLED: true,
-            AUTH_HEADER_ENABLED: false,
-          }[key];
-        });
-      });
-
-      describe('when called with no tokens', function () {
-        beforeEach(async function () {
-          const mockExecutionContext = createMock<ExecutionContext>({
-            switchToHttp: jest.fn().mockReturnValue({
-              getRequest: jest.fn().mockReturnValue({}),
-            }),
+          it('should resolve to false', async function () {
+            expect(result).toBe(false);
           });
 
-          result = await validRefreshTokenGuard.canActivate(
-            mockExecutionContext,
-          );
+          it('should validate no token', async function () {
+            expect(mockAuthService.validateRefreshToken).not.toHaveBeenCalled();
+          });
         });
 
-        it('should resolve to false', async function () {
-          expect(result).toBe(false);
-        });
+        describe('when called with valid token in body and cooki', function () {
+          beforeEach(async function () {
+            mockAuthService.validateRefreshToken.mockImplementationOnce(
+              async () => true,
+            );
 
-        it('should validate no token', async function () {
-          expect(mockAuthService.validateRefreshToken).not.toHaveBeenCalled();
-        });
-      });
-
-      describe('when called with valid token in cookie only', function () {
-        beforeEach(async function () {
-          mockAuthService.validateRefreshToken.mockImplementationOnce(
-            async () => true,
-          );
-
-          const mockExecutionContext = createMock<ExecutionContext>({
-            switchToHttp: jest.fn().mockReturnValue({
-              getRequest: jest.fn().mockReturnValue({
-                cookies: { refreshToken: 'cookie refresh token' },
+            const mockExecutionContext = createMock<ExecutionContext>({
+              switchToHttp: jest.fn().mockReturnValue({
+                getRequest: jest.fn().mockReturnValue({
+                  method,
+                  cookies: { refreshToken: 'cookie refresh token' },
+                  body: { refreshToken: 'body refresh token' },
+                }),
               }),
-            }),
+            });
+
+            result = await validRefreshTokenGuard.canActivate(
+              mockExecutionContext,
+            );
           });
 
-          result = await validRefreshTokenGuard.canActivate(
-            mockExecutionContext,
-          );
-        });
+          it('should resolve to false', async function () {
+            expect(result).toBe(false);
+          });
 
-        it('should resolve to true', async function () {
-          expect(result).toBe(true);
-        });
-
-        it('should validate cookie token', async function () {
-          expect(mockAuthService.validateRefreshToken).toHaveBeenCalledWith(
-            'cookie refresh token',
-          );
+          it('should validate no token', async function () {
+            expect(mockAuthService.validateRefreshToken).not.toHaveBeenCalled();
+          });
         });
       });
 
-      describe('when called with valid token in body only', function () {
+      describe('when AUTH_COOKIE_ENABLED==true && AUTH_HEADER_ENABLED=false', function () {
         beforeEach(async function () {
-          mockAuthService.validateRefreshToken.mockImplementationOnce(
-            async () => true,
-          );
+          mockConfigService.get.mockImplementation((key: string) => {
+            return {
+              ...configBase,
+              AUTH_COOKIE_ENABLED: true,
+              AUTH_HEADER_ENABLED: false,
+            }[key];
+          });
+        });
 
-          const mockExecutionContext = createMock<ExecutionContext>({
-            switchToHttp: jest.fn().mockReturnValue({
-              getRequest: jest.fn().mockReturnValue({
-                body: { refreshToken: 'body refresh token' },
+        describe('when called with no tokens', function () {
+          beforeEach(async function () {
+            const mockExecutionContext = createMock<ExecutionContext>({
+              switchToHttp: jest.fn().mockReturnValue({
+                getRequest: jest.fn().mockReturnValue({
+                  method,
+                }),
               }),
-            }),
+            });
+
+            result = await validRefreshTokenGuard.canActivate(
+              mockExecutionContext,
+            );
           });
 
-          result = await validRefreshTokenGuard.canActivate(
-            mockExecutionContext,
-          );
+          it('should resolve to false', async function () {
+            expect(result).toBe(false);
+          });
+
+          it('should validate no token', async function () {
+            expect(mockAuthService.validateRefreshToken).not.toHaveBeenCalled();
+          });
         });
 
-        it('should resolve to false', async function () {
-          expect(result).toBe(false);
-        });
+        describe('when called with valid token in cookie only', function () {
+          beforeEach(async function () {
+            mockAuthService.validateRefreshToken.mockImplementationOnce(
+              async () => true,
+            );
 
-        it('should validate no token', async function () {
-          expect(mockAuthService.validateRefreshToken).not.toHaveBeenCalled();
-        });
-      });
-
-      describe('when called with valid token in body and cookie', function () {
-        beforeEach(async function () {
-          mockAuthService.validateRefreshToken.mockImplementationOnce(
-            async () => true,
-          );
-
-          const mockExecutionContext = createMock<ExecutionContext>({
-            switchToHttp: jest.fn().mockReturnValue({
-              getRequest: jest.fn().mockReturnValue({
-                cookies: { refreshToken: 'cookie refresh token' },
-                body: { refreshToken: 'body refresh token' },
+            const mockExecutionContext = createMock<ExecutionContext>({
+              switchToHttp: jest.fn().mockReturnValue({
+                getRequest: jest.fn().mockReturnValue({
+                  method,
+                  cookies: { refreshToken: 'cookie refresh token' },
+                }),
               }),
-            }),
+            });
+
+            result = await validRefreshTokenGuard.canActivate(
+              mockExecutionContext,
+            );
           });
 
-          result = await validRefreshTokenGuard.canActivate(
-            mockExecutionContext,
-          );
-        });
-
-        it('should resolve to true', async function () {
-          expect(result).toBe(true);
-        });
-
-        it('should validate cookie token', async function () {
-          expect(mockAuthService.validateRefreshToken).toHaveBeenCalledWith(
-            'cookie refresh token',
-          );
-        });
-      });
-    });
-
-    describe('when AUTH_COOKIE_ENABLED==false && AUTH_HEADER_ENABLED=true', function () {
-      beforeEach(async function () {
-        mockConfigService.get.mockImplementation((key: string) => {
-          return {
-            ...configBase,
-            AUTH_COOKIE_ENABLED: false,
-            AUTH_HEADER_ENABLED: true,
-          }[key];
-        });
-      });
-
-      describe('when called with no tokens', function () {
-        beforeEach(async function () {
-          const mockExecutionContext = createMock<ExecutionContext>({
-            switchToHttp: jest.fn().mockReturnValue({
-              getRequest: jest.fn().mockReturnValue({}),
-            }),
+          it('should resolve to true', async function () {
+            expect(result).toBe(true);
           });
 
-          result = await validRefreshTokenGuard.canActivate(
-            mockExecutionContext,
-          );
+          it('should validate cookie token', async function () {
+            expect(mockAuthService.validateRefreshToken).toHaveBeenCalledWith(
+              'cookie refresh token',
+            );
+          });
         });
 
-        it('should resolve to false', async function () {
-          expect(result).toBe(false);
-        });
+        describe('when called with valid token in body only', function () {
+          beforeEach(async function () {
+            mockAuthService.validateRefreshToken.mockImplementationOnce(
+              async () => true,
+            );
 
-        it('should validate no token', async function () {
-          expect(mockAuthService.validateRefreshToken).not.toHaveBeenCalled();
-        });
-      });
-
-      describe('when called with valid token in cookie only', function () {
-        beforeEach(async function () {
-          mockAuthService.validateRefreshToken.mockImplementationOnce(
-            async () => true,
-          );
-
-          const mockExecutionContext = createMock<ExecutionContext>({
-            switchToHttp: jest.fn().mockReturnValue({
-              getRequest: jest.fn().mockReturnValue({
-                cookies: { refreshToken: 'cookie refresh token' },
+            const mockExecutionContext = createMock<ExecutionContext>({
+              switchToHttp: jest.fn().mockReturnValue({
+                getRequest: jest.fn().mockReturnValue({
+                  method,
+                  body: { refreshToken: 'body refresh token' },
+                }),
               }),
-            }),
+            });
+
+            result = await validRefreshTokenGuard.canActivate(
+              mockExecutionContext,
+            );
           });
 
-          result = await validRefreshTokenGuard.canActivate(
-            mockExecutionContext,
-          );
+          it('should resolve to false', async function () {
+            expect(result).toBe(false);
+          });
+
+          it('should validate no token', async function () {
+            expect(mockAuthService.validateRefreshToken).not.toHaveBeenCalled();
+          });
         });
 
-        it('should resolve to false', async function () {
-          expect(result).toBe(false);
-        });
+        describe('when called with valid token in body and cookie', function () {
+          beforeEach(async function () {
+            mockAuthService.validateRefreshToken.mockImplementationOnce(
+              async () => true,
+            );
 
-        it('should validate no token', async function () {
-          expect(mockAuthService.validateRefreshToken).not.toHaveBeenCalled();
-        });
-      });
-
-      describe('when called with valid token in body only', function () {
-        beforeEach(async function () {
-          mockAuthService.validateRefreshToken.mockImplementationOnce(
-            async () => true,
-          );
-
-          const mockExecutionContext = createMock<ExecutionContext>({
-            switchToHttp: jest.fn().mockReturnValue({
-              getRequest: jest.fn().mockReturnValue({
-                body: { refreshToken: 'body refresh token' },
+            const mockExecutionContext = createMock<ExecutionContext>({
+              switchToHttp: jest.fn().mockReturnValue({
+                getRequest: jest.fn().mockReturnValue({
+                  method,
+                  cookies: { refreshToken: 'cookie refresh token' },
+                  body: { refreshToken: 'body refresh token' },
+                }),
               }),
-            }),
+            });
+
+            result = await validRefreshTokenGuard.canActivate(
+              mockExecutionContext,
+            );
           });
 
-          result = await validRefreshTokenGuard.canActivate(
-            mockExecutionContext,
-          );
-        });
+          it('should resolve to true', async function () {
+            expect(result).toBe(true);
+          });
 
-        it('should resolve to true', async function () {
-          expect(result).toBe(true);
-        });
-
-        it('should validate body token', async function () {
-          expect(mockAuthService.validateRefreshToken).toHaveBeenCalledWith(
-            'body refresh token',
-          );
+          it('should validate cookie token', async function () {
+            expect(mockAuthService.validateRefreshToken).toHaveBeenCalledWith(
+              'cookie refresh token',
+            );
+          });
         });
       });
 
-      describe('when called with valid token in body and cookie', function () {
+      describe('when AUTH_COOKIE_ENABLED==false && AUTH_HEADER_ENABLED=true', function () {
         beforeEach(async function () {
-          mockAuthService.validateRefreshToken.mockImplementationOnce(
-            async () => true,
-          );
+          mockConfigService.get.mockImplementation((key: string) => {
+            return {
+              ...configBase,
+              AUTH_COOKIE_ENABLED: false,
+              AUTH_HEADER_ENABLED: true,
+            }[key];
+          });
+        });
 
-          const mockExecutionContext = createMock<ExecutionContext>({
-            switchToHttp: jest.fn().mockReturnValue({
-              getRequest: jest.fn().mockReturnValue({
-                cookies: { refreshToken: 'cookie refresh token' },
-                body: { refreshToken: 'body refresh token' },
+        describe('when called with no tokens', function () {
+          beforeEach(async function () {
+            const mockExecutionContext = createMock<ExecutionContext>({
+              switchToHttp: jest.fn().mockReturnValue({
+                getRequest: jest.fn().mockReturnValue({
+                  method,
+                }),
               }),
-            }),
+            });
+
+            result = await validRefreshTokenGuard.canActivate(
+              mockExecutionContext,
+            );
           });
 
-          result = await validRefreshTokenGuard.canActivate(
-            mockExecutionContext,
-          );
-        });
-
-        it('should resolve to true', async function () {
-          expect(result).toBe(true);
-        });
-
-        it('should validate body token', async function () {
-          expect(mockAuthService.validateRefreshToken).toHaveBeenCalledWith(
-            'body refresh token',
-          );
-        });
-      });
-    });
-
-    describe('when AUTH_COOKIE_ENABLED==true && AUTH_HEADER_ENABLED=true', function () {
-      beforeEach(async function () {
-        mockConfigService.get.mockImplementation((key: string) => {
-          return {
-            ...configBase,
-            AUTH_COOKIE_ENABLED: true,
-            AUTH_HEADER_ENABLED: true,
-          }[key];
-        });
-      });
-
-      describe('when called with no tokens', function () {
-        beforeEach(async function () {
-          const mockExecutionContext = createMock<ExecutionContext>({
-            switchToHttp: jest.fn().mockReturnValue({
-              getRequest: jest.fn().mockReturnValue({}),
-            }),
+          it('should resolve to false', async function () {
+            expect(result).toBe(false);
           });
 
-          result = await validRefreshTokenGuard.canActivate(
-            mockExecutionContext,
-          );
+          it('should validate no token', async function () {
+            expect(mockAuthService.validateRefreshToken).not.toHaveBeenCalled();
+          });
         });
 
-        it('should resolve to false', async function () {
-          expect(result).toBe(false);
-        });
+        describe('when called with valid token in cookie only', function () {
+          beforeEach(async function () {
+            mockAuthService.validateRefreshToken.mockImplementationOnce(
+              async () => true,
+            );
 
-        it('should validate no token', async function () {
-          expect(mockAuthService.validateRefreshToken).not.toHaveBeenCalled();
-        });
-      });
-
-      describe('when called with valid token in cookie only', function () {
-        beforeEach(async function () {
-          mockAuthService.validateRefreshToken.mockImplementationOnce(
-            async () => true,
-          );
-
-          const mockExecutionContext = createMock<ExecutionContext>({
-            switchToHttp: jest.fn().mockReturnValue({
-              getRequest: jest.fn().mockReturnValue({
-                cookies: { refreshToken: 'cookie refresh token' },
+            const mockExecutionContext = createMock<ExecutionContext>({
+              switchToHttp: jest.fn().mockReturnValue({
+                getRequest: jest.fn().mockReturnValue({
+                  method,
+                  cookies: { refreshToken: 'cookie refresh token' },
+                }),
               }),
-            }),
+            });
+
+            result = await validRefreshTokenGuard.canActivate(
+              mockExecutionContext,
+            );
           });
 
-          result = await validRefreshTokenGuard.canActivate(
-            mockExecutionContext,
-          );
+          it('should resolve to false', async function () {
+            expect(result).toBe(false);
+          });
+
+          it('should validate no token', async function () {
+            expect(mockAuthService.validateRefreshToken).not.toHaveBeenCalled();
+          });
         });
 
-        it('should resolve to true', async function () {
-          expect(result).toBe(true);
+        describe('when called with valid token in body only', function () {
+          beforeEach(async function () {
+            mockAuthService.validateRefreshToken.mockImplementationOnce(
+              async () => true,
+            );
+
+            const mockExecutionContext = createMock<ExecutionContext>({
+              switchToHttp: jest.fn().mockReturnValue({
+                getRequest: jest.fn().mockReturnValue({
+                  method,
+                  body: { refreshToken: 'body refresh token' },
+                }),
+              }),
+            });
+
+            result = await validRefreshTokenGuard.canActivate(
+              mockExecutionContext,
+            );
+          });
+
+          it('should resolve to true', async function () {
+            expect(result).toBe(true);
+          });
+
+          it('should validate body token', async function () {
+            expect(mockAuthService.validateRefreshToken).toHaveBeenCalledWith(
+              'body refresh token',
+            );
+          });
         });
 
-        it('should validate cookie token', async function () {
-          expect(mockAuthService.validateRefreshToken).toHaveBeenCalledWith(
-            'cookie refresh token',
-          );
+        describe('when called with valid token in body and cookie', function () {
+          beforeEach(async function () {
+            mockAuthService.validateRefreshToken.mockImplementationOnce(
+              async () => true,
+            );
+
+            const mockExecutionContext = createMock<ExecutionContext>({
+              switchToHttp: jest.fn().mockReturnValue({
+                getRequest: jest.fn().mockReturnValue({
+                  method,
+                  cookies: { refreshToken: 'cookie refresh token' },
+                  body: { refreshToken: 'body refresh token' },
+                }),
+              }),
+            });
+
+            result = await validRefreshTokenGuard.canActivate(
+              mockExecutionContext,
+            );
+          });
+
+          it('should resolve to true', async function () {
+            expect(result).toBe(true);
+          });
+
+          it('should validate body token', async function () {
+            expect(mockAuthService.validateRefreshToken).toHaveBeenCalledWith(
+              'body refresh token',
+            );
+          });
         });
       });
 
-      describe('when called with valid token in body only', function () {
+      describe('when AUTH_COOKIE_ENABLED==true && AUTH_HEADER_ENABLED=true', function () {
         beforeEach(async function () {
-          mockAuthService.validateRefreshToken.mockImplementationOnce(
-            async () => true,
-          );
+          mockConfigService.get.mockImplementation((key: string) => {
+            return {
+              ...configBase,
+              AUTH_COOKIE_ENABLED: true,
+              AUTH_HEADER_ENABLED: true,
+            }[key];
+          });
+        });
 
-          const mockExecutionContext = createMock<ExecutionContext>({
-            switchToHttp: jest.fn().mockReturnValue({
-              getRequest: jest.fn().mockReturnValue({
-                body: { refreshToken: 'body refresh token' },
+        describe('when called with no tokens', function () {
+          beforeEach(async function () {
+            const mockExecutionContext = createMock<ExecutionContext>({
+              switchToHttp: jest.fn().mockReturnValue({
+                getRequest: jest.fn().mockReturnValue({
+                  method,
+                }),
               }),
-            }),
+            });
+
+            result = await validRefreshTokenGuard.canActivate(
+              mockExecutionContext,
+            );
           });
 
-          result = await validRefreshTokenGuard.canActivate(
-            mockExecutionContext,
-          );
-        });
-
-        it('should resolve to true', async function () {
-          expect(result).toBe(true);
-        });
-
-        it('should validate body token', async function () {
-          expect(mockAuthService.validateRefreshToken).toHaveBeenCalledWith(
-            'body refresh token',
-          );
-        });
-      });
-
-      describe('when called with valid token in body and cookie', function () {
-        beforeEach(async function () {
-          mockAuthService.validateRefreshToken.mockImplementationOnce(
-            async () => true,
-          );
-
-          const mockExecutionContext = createMock<ExecutionContext>({
-            switchToHttp: jest.fn().mockReturnValue({
-              getRequest: jest.fn().mockReturnValue({
-                cookies: { refreshToken: 'cookie refresh token' },
-                body: { refreshToken: 'body refresh token' },
-              }),
-            }),
+          it('should resolve to false', async function () {
+            expect(result).toBe(false);
           });
 
-          result = await validRefreshTokenGuard.canActivate(
-            mockExecutionContext,
-          );
+          it('should validate no token', async function () {
+            expect(mockAuthService.validateRefreshToken).not.toHaveBeenCalled();
+          });
         });
 
-        it('should resolve to true', async function () {
-          expect(result).toBe(true);
+        describe('when called with valid token in cookie only', function () {
+          beforeEach(async function () {
+            mockAuthService.validateRefreshToken.mockImplementationOnce(
+              async () => true,
+            );
+
+            const mockExecutionContext = createMock<ExecutionContext>({
+              switchToHttp: jest.fn().mockReturnValue({
+                getRequest: jest.fn().mockReturnValue({
+                  method,
+                  cookies: { refreshToken: 'cookie refresh token' },
+                }),
+              }),
+            });
+
+            result = await validRefreshTokenGuard.canActivate(
+              mockExecutionContext,
+            );
+          });
+
+          it('should resolve to true', async function () {
+            expect(result).toBe(true);
+          });
+
+          it('should validate cookie token', async function () {
+            expect(mockAuthService.validateRefreshToken).toHaveBeenCalledWith(
+              'cookie refresh token',
+            );
+          });
         });
 
-        it('should validate body token', async function () {
-          expect(mockAuthService.validateRefreshToken).toHaveBeenCalledWith(
-            'body refresh token',
-          );
+        describe('when called with valid token in body only', function () {
+          beforeEach(async function () {
+            mockAuthService.validateRefreshToken.mockImplementationOnce(
+              async () => true,
+            );
+
+            const mockExecutionContext = createMock<ExecutionContext>({
+              switchToHttp: jest.fn().mockReturnValue({
+                getRequest: jest.fn().mockReturnValue({
+                  method,
+                  body: { refreshToken: 'body refresh token' },
+                }),
+              }),
+            });
+
+            result = await validRefreshTokenGuard.canActivate(
+              mockExecutionContext,
+            );
+          });
+
+          it('should resolve to true', async function () {
+            expect(result).toBe(true);
+          });
+
+          it('should validate body token', async function () {
+            expect(mockAuthService.validateRefreshToken).toHaveBeenCalledWith(
+              'body refresh token',
+            );
+          });
+        });
+
+        describe('when called with valid token in body and cookie', function () {
+          beforeEach(async function () {
+            mockAuthService.validateRefreshToken.mockImplementationOnce(
+              async () => true,
+            );
+
+            const mockExecutionContext = createMock<ExecutionContext>({
+              switchToHttp: jest.fn().mockReturnValue({
+                getRequest: jest.fn().mockReturnValue({
+                  method,
+                  cookies: { refreshToken: 'cookie refresh token' },
+                  body: { refreshToken: 'body refresh token' },
+                }),
+              }),
+            });
+
+            result = await validRefreshTokenGuard.canActivate(
+              mockExecutionContext,
+            );
+          });
+
+          it('should resolve to true', async function () {
+            expect(result).toBe(true);
+          });
+
+          it('should validate body token', async function () {
+            expect(mockAuthService.validateRefreshToken).toHaveBeenCalledWith(
+              'body refresh token',
+            );
+          });
         });
       });
     });

--- a/authorization-server/src/modules/auth/guards/valid-refresh-token.guard.spec.ts
+++ b/authorization-server/src/modules/auth/guards/valid-refresh-token.guard.spec.ts
@@ -4,7 +4,7 @@ import { AuthService } from '../auth.service';
 import { JwtModule } from '@nestjs/jwt';
 import { ValidRefreshTokenGuard } from './valid-refresh-token.guard';
 import { createMock } from '@golevelup/ts-jest';
-import { ExecutionContext } from '@nestjs/common';
+import { ExecutionContext, UnauthorizedException } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 
 describe('ValidRefreshTokenGuard', () => {
@@ -130,6 +130,32 @@ describe('ValidRefreshTokenGuard', () => {
       it('should return result of validation', async function () {
         expect(result).toBe('result of token validation');
       });
+
+      describe('when no token provided', function () {
+        beforeEach(async function () {
+          jest
+            .spyOn(validRefreshTokenGuard, 'extractFromPostBodyOrCookies')
+            .mockReturnValueOnce(null);
+
+          const mockExecutionContext = createMock<ExecutionContext>({
+            switchToHttp: jest.fn().mockReturnValue({
+              getRequest: jest.fn().mockReturnValue({ method }),
+            }),
+          });
+
+          try {
+            result = await validRefreshTokenGuard.canActivate(
+              mockExecutionContext,
+            );
+          } catch (err) {
+            exception = err;
+          }
+        });
+
+        it('should throw `UnauthorizedException`', async function () {
+          expect(exception).toBeInstanceOf(UnauthorizedException);
+        });
+      });
     });
 
     describe('when method is GET', function () {
@@ -184,6 +210,32 @@ describe('ValidRefreshTokenGuard', () => {
 
       it('should return result of validation', async function () {
         expect(result).toBe('result of token validation');
+      });
+
+      describe('when no token provided', function () {
+        beforeEach(async function () {
+          jest
+            .spyOn(validRefreshTokenGuard, 'extractFromQueryStringOrCookies')
+            .mockReturnValueOnce(null);
+
+          const mockExecutionContext = createMock<ExecutionContext>({
+            switchToHttp: jest.fn().mockReturnValue({
+              getRequest: jest.fn().mockReturnValue({ method }),
+            }),
+          });
+
+          try {
+            result = await validRefreshTokenGuard.canActivate(
+              mockExecutionContext,
+            );
+          } catch (err) {
+            exception = err;
+          }
+        });
+
+        it('should throw `UnauthorizedException`', async function () {
+          expect(exception).toBeInstanceOf(UnauthorizedException);
+        });
       });
     });
 

--- a/authorization-server/src/modules/auth/guards/valid-refresh-token.guard.ts
+++ b/authorization-server/src/modules/auth/guards/valid-refresh-token.guard.ts
@@ -7,6 +7,7 @@ import {
 import { AuthService } from '../auth.service';
 import { ConfigService } from '@nestjs/config';
 import { Request } from 'express';
+import { RefreshDto } from '../dto';
 
 export class ValidRefreshTokenGuard implements CanActivate {
   constructor(
@@ -17,23 +18,11 @@ export class ValidRefreshTokenGuard implements CanActivate {
   async canActivate(context: ExecutionContext): Promise<boolean> {
     const request: Request = context.switchToHttp().getRequest();
     const { body, cookies, method } = request;
-    const AUTH_HEADER_ENABLED = this.config.get<boolean>('AUTH_HEADER_ENABLED');
-    const AUTH_COOKIE_ENABLED = this.config.get<boolean>('AUTH_COOKIE_ENABLED');
 
-    let refreshToken: string;
+    let refreshToken: string | undefined;
 
     if (method === 'POST') {
-      if (AUTH_COOKIE_ENABLED && AUTH_HEADER_ENABLED) {
-        refreshToken =
-          body?.refreshToken ||
-          (cookies || {})[this.config.get('AUTH_COOKIE_NAME_REFRESH_TOKEN')];
-      } else if (AUTH_COOKIE_ENABLED) {
-        refreshToken = (cookies || {})[
-          this.config.get('AUTH_COOKIE_NAME_REFRESH_TOKEN')
-        ];
-      } else if (AUTH_HEADER_ENABLED) {
-        refreshToken = body?.refreshToken;
-      }
+      refreshToken = this.extractFromPostBodyOrCookies(body, cookies);
     } else if (method === 'GET') {
       throw new NotImplementedException();
     } else {
@@ -46,6 +35,31 @@ export class ValidRefreshTokenGuard implements CanActivate {
       return false;
     }
 
+    request.user = refreshToken;
+
     return await this.authService.validateRefreshToken(refreshToken);
+  }
+
+  extractFromPostBodyOrCookies(
+    body?: RefreshDto,
+    cookies?: Record<string, string>,
+  ): string | undefined {
+    let refreshToken: string | undefined;
+    const AUTH_HEADER_ENABLED = this.config.get<boolean>('AUTH_HEADER_ENABLED');
+    const AUTH_COOKIE_ENABLED = this.config.get<boolean>('AUTH_COOKIE_ENABLED');
+
+    if (AUTH_COOKIE_ENABLED && AUTH_HEADER_ENABLED) {
+      refreshToken =
+        body?.refreshToken ||
+        (cookies || {})[this.config.get('AUTH_COOKIE_NAME_REFRESH_TOKEN')];
+    } else if (AUTH_COOKIE_ENABLED) {
+      refreshToken = (cookies || {})[
+        this.config.get('AUTH_COOKIE_NAME_REFRESH_TOKEN')
+      ];
+    } else if (AUTH_HEADER_ENABLED) {
+      refreshToken = body?.refreshToken;
+    }
+
+    return refreshToken;
   }
 }

--- a/authorization-server/src/modules/auth/guards/valid-refresh-token.guard.ts
+++ b/authorization-server/src/modules/auth/guards/valid-refresh-token.guard.ts
@@ -1,4 +1,9 @@
-import { CanActivate, ExecutionContext, Inject } from '@nestjs/common';
+import {
+  CanActivate,
+  ExecutionContext,
+  Inject,
+  UnauthorizedException,
+} from '@nestjs/common';
 import { AuthService } from '../auth.service';
 import { ConfigService } from '@nestjs/config';
 import { Request } from 'express';
@@ -30,7 +35,7 @@ export class ValidRefreshTokenGuard implements CanActivate {
     }
 
     if (!refreshToken) {
-      return false;
+      throw new UnauthorizedException();
     }
 
     request.user = refreshToken;

--- a/authorization-server/src/modules/auth/guards/valid-refresh-token.guard.ts
+++ b/authorization-server/src/modules/auth/guards/valid-refresh-token.guard.ts
@@ -16,8 +16,8 @@ export class ValidRefreshTokenGuard implements CanActivate {
   ) {}
 
   async canActivate(context: ExecutionContext): Promise<boolean> {
-    const request: Request = context.switchToHttp().getRequest();
-    const { body, cookies, method } = request;
+    const request = context.switchToHttp().getRequest<Request>();
+    const { body, cookies, method, query } = request;
 
     let refreshToken: string | undefined;
 
@@ -25,8 +25,8 @@ export class ValidRefreshTokenGuard implements CanActivate {
       refreshToken = this.extractFromPostBodyOrCookies(body, cookies);
     } else if (method === 'GET') {
       refreshToken = this.extractFromQueryStringOrCookies(
-        request.cookies,
-        request.query as { refresh_token?: string },
+        cookies,
+        query as { refresh_token?: string },
       );
     } else {
       throw new Error(
@@ -70,11 +70,12 @@ export class ValidRefreshTokenGuard implements CanActivate {
     cookies?: Record<string, string>,
     query?: { refresh_token?: string },
   ): string | undefined {
-    let refreshToken: string;
+    let refreshToken: string | undefined;
     const AUTH_HEADER_ENABLED = this.config.get<boolean>('AUTH_HEADER_ENABLED');
     const AUTH_COOKIE_ENABLED = this.config.get<boolean>('AUTH_COOKIE_ENABLED');
 
-    const refreshTokenFromQueryString: string = query && query['refresh_token'];
+    const refreshTokenFromQueryString: string | undefined =
+      query && query['refresh_token'];
 
     if (AUTH_COOKIE_ENABLED && AUTH_HEADER_ENABLED) {
       refreshToken =

--- a/authorization-server/test/app.e2e-spec.ts
+++ b/authorization-server/test/app.e2e-spec.ts
@@ -629,8 +629,8 @@ describe('AppController (e2e)', () => {
         response = await request(appHttpServer).post('/auth/refresh-token');
       });
 
-      it('should respond with 403 status code', async function () {
-        expect(response.statusCode).toBe(403);
+      it('should respond with 401 status code', async function () {
+        expect(response.statusCode).toBe(401);
       });
     });
 
@@ -819,8 +819,8 @@ describe('AppController (e2e)', () => {
           .send({});
       });
 
-      it('should respond with 403 status code', async function () {
-        expect(response.statusCode).toBe(403);
+      it('should respond with 401 status code', async function () {
+        expect(response.statusCode).toBe(401);
       });
     });
 

--- a/authorization-server/test/app.e2e-spec.ts
+++ b/authorization-server/test/app.e2e-spec.ts
@@ -682,6 +682,114 @@ describe('AppController (e2e)', () => {
     });
   });
 
+  describe('/auth/refresh_token (GET)', function () {
+    let response: Response;
+
+    describe('when called with a valid refresh token', function () {
+      let refreshToken: string;
+
+      beforeEach(async function () {
+        const start = Date.now();
+        ({ refreshToken } = await logIn(appHttpServer, identityToken));
+
+        console.log(`logged in in ${Date.now() - start}ms`);
+
+        response = await request(appHttpServer).get(
+          `/auth/refresh_token?refresh_token=${refreshToken}`,
+        );
+      });
+
+      it('should respond with 200 status code', async function () {
+        expect(response.statusCode).toBe(200);
+      });
+
+      it('should respond with a body containing access and refresh tokens', async function () {
+        expect(response.body).toEqual(
+          expect.objectContaining({
+            access_token: expect.any(String),
+            refresh_token: expect.any(String),
+          }),
+        );
+      });
+    });
+
+    describe('when called with an invalid refresh token', function () {
+      beforeEach(async function () {
+        response = await request(appHttpServer).get(
+          `/auth/refresh_token?refresh_token=invalid-token`,
+        );
+      });
+
+      it('should respond with 403 status code', async function () {
+        expect(response.statusCode).toBe(403);
+      });
+
+      it('should respond with a body containing no access nor refresh tokens', async function () {
+        expect(response.body).toEqual(
+          expect.not.objectContaining({
+            access_token: expect.any(String),
+          }),
+        );
+
+        expect(response.body).toEqual(
+          expect.not.objectContaining({
+            refresh_token: expect.any(String),
+          }),
+        );
+      });
+    });
+
+    describe('when called with no refresh token', function () {
+      beforeEach(async function () {
+        response = await request(appHttpServer).get(`/auth/refresh_token`);
+      });
+
+      it('should respond with 401 status code', async function () {
+        expect(response.statusCode).toBe(401);
+      });
+
+      it('should respond with a body containing no access nor refresh tokens', async function () {
+        expect(response.body).toEqual(
+          expect.not.objectContaining({
+            access_token: expect.any(String),
+          }),
+        );
+
+        expect(response.body).toEqual(
+          expect.not.objectContaining({
+            refresh_token: expect.any(String),
+          }),
+        );
+      });
+    });
+
+    describe('when called with empty refresh token', function () {
+      beforeEach(async function () {
+        response = await request(appHttpServer).get(
+          `/auth/refresh_token?refresh_token=`,
+        );
+      });
+
+      it('should respond with 401 status code', async function () {
+        expect(response.statusCode).toBe(401);
+      });
+
+      it('should respond with a body containing no access nor refresh tokens', async function () {
+        expect(response.body).toEqual(
+          expect.not.objectContaining({
+            access_token: expect.any(String),
+          }),
+        );
+
+        expect(response.body).toEqual(
+          expect.not.objectContaining({
+            refresh_token: expect.any(String),
+          }),
+        );
+      });
+    });
+  });
+
   describe('/auth/logout', function () {
     describe('whan called with a valid refresh token', function () {
       let refreshToken: string;


### PR DESCRIPTION
This PR adds an endpoint required to achieve API compatibility with SSI-HUB.