### PR TITLE
chore(prod & staging values): fix ssi-hub url to match SIWE URI

### DIFF
--- a/devops/iam-did-auth-proxy-prod/values.yaml
+++ b/devops/iam-did-auth-proxy-prod/values.yaml
@@ -69,7 +69,7 @@ did-auth-proxy-helm:
 
   opsValues:
     RPC_URL: https://rpc.energyweb.org/
-    CACHE_SERVER_URL: http://ics.gp4btc.svc.cluster.local:3000/v1
+    CACHE_SERVER_URL: https://identitycache-gp4btc.energyweb.org/v1
     REDIS_HOST: iam-did-auth-proxy-redis-master.iam-did-auth-proxy.svc.cluster.local
     REDIS_PORT: 6379
     REDIS_PASSWORD: redis

--- a/devops/iam-did-auth-proxy-staging/values.yaml
+++ b/devops/iam-did-auth-proxy-staging/values.yaml
@@ -69,7 +69,7 @@ did-auth-proxy-helm:
 
   opsValues:
     RPC_URL: https://volta-rpc.energyweb.org/
-    CACHE_SERVER_URL: http://ics.gp4btc.svc.cluster.local:3000/v1
+    CACHE_SERVER_URL: https://identitycache-gp4btc-staging.energyweb.org/v1
     REDIS_HOST: iam-did-auth-proxy-redis-master.iam-did-auth-proxy.svc.cluster.local
     REDIS_PORT: 6379
     REDIS_PASSWORD: redis


### PR DESCRIPTION
did-auth-proxy in staging is not quite ready. I think the issue is that uri in the message composed by did-auth-proxy (in passport-did-auth) to login to ssi-hub. Below are logs from ssi-hub gp4btc-staging from about the same time.
```
[Nest] 1  - 04/24/2023, 3:26:58 PM   ERROR [ExceptionsHandler] uri in siwe message payload is incorrect
393
Error: uri in siwe message payload is incorrect
392
    at AuthStrategy.<anonymous> (/app/node_modules/passport-did-auth/dist/lib/LoginStrategy.js:151:29)
```
I think in order to use the internal k8s URL for ssi-hub, we would need to make a change to passport-did-auth to allow the specification of an SIWE Message URI that is different from the URL that the strategy is actually using to login (as we've done in iam-kyc-app). However, for now, I think the easiest thing to do is to use the public URL for gp4btc ssi-hub staging and prod as this is what these instance are expected.