### PR TITLE
fix(auth.controller): set clearCookie options

### DIFF
--- a/authorization-server/src/modules/auth/auth.controller.ts
+++ b/authorization-server/src/modules/auth/auth.controller.ts
@@ -270,7 +270,9 @@ export class AuthController {
     [
       this.configService.get<string>('AUTH_COOKIE_NAME_ACCESS_TOKEN'),
       this.configService.get<string>('AUTH_COOKIE_NAME_REFRESH_TOKEN'),
-    ].forEach((cookieName: string) => res.clearCookie(cookieName));
+    ].forEach((cookieName: string) =>
+      res.clearCookie(cookieName, this.authService.getAuthCookiesOptions()),
+    );
   }
 }
 


### PR DESCRIPTION
Response cookies also need to have `sameSite=None` set to work cross-origin.
I haven't tested this locally, but I'm moderately confident that it would work.