### PR TITLE
fix: fixing secure flag required to be set when unsetting cookies

### DIFF
--- a/authorization-server/src/modules/auth/auth.controller.spec.ts
+++ b/authorization-server/src/modules/auth/auth.controller.spec.ts
@@ -785,6 +785,7 @@ describe('AuthController', () => {
         expect(cookie.value).toBe('');
         expect(cookie.options.expires).toEqual(new Date(1));
         expect(cookie.options.sameSite).toBe(authCookieSettingsBase.sameSite);
+        expect(cookie.options.secure).toBe(authCookieSettingsBase.secure);
       });
 
       it('should unset refresh token cookie', async function () {
@@ -797,6 +798,7 @@ describe('AuthController', () => {
         expect(cookie.value).toBe('');
         expect(cookie.options.expires).toEqual(new Date(1));
         expect(cookie.options.sameSite).toBe(authCookieSettingsBase.sameSite);
+        expect(cookie.options.secure).toBe(authCookieSettingsBase.secure);
       });
     });
 

--- a/authorization-server/src/modules/auth/auth.controller.ts
+++ b/authorization-server/src/modules/auth/auth.controller.ts
@@ -267,13 +267,13 @@ export class AuthController {
   }
 
   private unsetAuthCookies(res: Response) {
-    const { sameSite } = this.authService.getAuthCookiesOptions();
+    const { sameSite, secure } = this.authService.getAuthCookiesOptions();
 
     [
       this.configService.get<string>('AUTH_COOKIE_NAME_ACCESS_TOKEN'),
       this.configService.get<string>('AUTH_COOKIE_NAME_REFRESH_TOKEN'),
     ].forEach((cookieName: string) =>
-      res.clearCookie(cookieName, { sameSite }),
+      res.clearCookie(cookieName, { sameSite, secure }),
     );
   }
 }


### PR DESCRIPTION
A secure flag needs to be set when unsetting cookies cross-site.